### PR TITLE
fix: env ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ which change per-environment, this tool can help.
 Perform variable substitution across the template, based on environment variables.
 
 ## Define variables in numerous ways
-Accepts variables from INI-style environment files, command switches, or the current environment
+Accepts variables from INI-style environment files, or command switches.
+
+* `.ini` files (eg `--ini global.ini --ini local.ini`) are processed in the order they are provided, with duplicate keys overriding earlier
+* env vars (`-e FOO=foo`) are applied after `.ini`
 
 ## Remove keys you do not need
 Exclude keys from final output (eg if you use a labels-based router such as [traefik](https://traefik.io) in some environments, and

--- a/src/EnvironmentLoader.php
+++ b/src/EnvironmentLoader.php
@@ -3,22 +3,25 @@ namespace dcgen;
 
 class EnvironmentLoader
 {
-    private $filenames;
+    private $settings = [];
 
-    public function __construct(array $iniFiles)
+    public function load(array $iniFiles): void
     {
-        $this->filenames = $iniFiles;
-    }
-
-    public function load(): array
-    {
-        $settings = [];
-        foreach ($this->filenames as $filename) {
+        foreach ($iniFiles as $filename) {
             if (!file_exists($filename)) {
                 throw new \RuntimeException('File not found: '.$filename);
             }
-            $settings += parse_ini_file($filename);
+            $this->settings = array_merge($this->settings, parse_ini_file($filename));
         }
-        return $settings;
+    }
+
+    public function get(): array
+    {
+        return $this->settings;
+    }
+
+    public function add(array $settings): void
+    {
+        $this->settings = array_merge($this->settings, $settings);
     }
 }

--- a/tests/EnvironmentLoaderTest.php
+++ b/tests/EnvironmentLoaderTest.php
@@ -1,0 +1,28 @@
+<?php
+namespace dcgen\Test;
+
+use dcgen\EnvironmentLoader;
+use PHPUnit\Framework\TestCase;
+
+class EnvironmentLoaderTest extends TestCase
+{
+    public function testLaterSettingsOverrideEarlier()
+    {
+        $filenames = [
+            __DIR__.'/input/env.ini',
+            __DIR__.'/input/bar.override.ini',
+        ];
+        $loader = new EnvironmentLoader();
+        $loader->load($filenames);
+        $expected = [
+            'FOO' => 'foo',
+            'BAR' => 'elephant',
+            'BAZ' => 'baz',
+        ];
+        $this->assertEquals($expected, $loader->get());
+
+        $loader->add(['BAR' => 'kangaroo']);
+        $expected['BAR'] = 'kangaroo';
+        $this->assertEquals($expected, $loader->get());
+    }
+}

--- a/tests/input/bar.override.ini
+++ b/tests/input/bar.override.ini
@@ -1,0 +1,1 @@
+BAR=elephant


### PR DESCRIPTION
Ensure settings in later .ini files override earlier, and that env vars (via --env/-e)
override earlier .ini settings