### PR TITLE
fixing an env var with equals signs

### DIFF
--- a/src/Command/GenerateCommand.php
+++ b/src/Command/GenerateCommand.php
@@ -35,7 +35,7 @@ class GenerateCommand extends Command
         }
         $settings = [];
         foreach ((array)$input->getOption('env') as $pair) {
-            list($k, $v) = explode('=', $pair);
+            list($k, $v) = explode('=', $pair, 2);
             $settings[$k] = $v;
         }
         $iniFiles = (array)$input->getOption('ini');

--- a/tests/input/simple.yml
+++ b/tests/input/simple.yml
@@ -1,0 +1,3 @@
+foo:
+  variables:
+    bar: "{{BAR}}"

--- a/tests/phpt/replace_env_var_with_equals.phpt
+++ b/tests/phpt/replace_env_var_with_equals.phpt
@@ -1,0 +1,10 @@
+--TEST--
+generate test, replace from env var with equals signs - only split on first =, and retain the rest
+--FILE--
+<?php
+echo shell_exec('bin/dcgen generate -e BAR=BAR== < tests/input/simple.yml 2>/dev/null');
+?>
+--EXPECT--
+foo:
+  variables:
+    bar: 'BAR=='


### PR DESCRIPTION
everything after the first = sign in an env var was being lost. correctly split only on the first = sign, not all.